### PR TITLE
Add react

### DIFF
--- a/src/hooks/user_state_with_storage.ts
+++ b/src/hooks/user_state_with_storage.ts
@@ -1,0 +1,12 @@
+import { useState } from 'react'
+// init: string は初期値で、useStateの引数と同じ、key: string は localStorageに保存するキー、[string, (s: string) => void] はカスタムフックの戻り値
+export const useStateWithStorage = (init: string, key: string): [string, (s: string) => void] => {
+  const [value, setValue] = useState<string>(localStorage.getItem(key) || init)
+
+  const setValueWithStorage = (nextValue: string): void => {
+    setValue(nextValue)
+    localStorage.setItem(key, nextValue)
+  }
+
+  return [value, setValueWithStorage]
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,23 @@
 import * as React from 'react'
 import { render } from 'react-dom'
 import styled from 'styled-components' // styled-components をインポート
+import { createGlobalStyle } from 'styled-components'
+import { Editor } from './pages/editor' // editor.tsxをインポートし、下で呼び出す(表示)
 
-const Header = styled.h1`
-  color:red;
+// スタイルをページ全体に適用
+const GlobalStyle = createGlobalStyle`
+    body * {
+      box-sizing: border-box;
+    }
   `
-
-  const Main = (<Header>Markdown Editor</Header>)
+  
+  const Main = (
+    <>
+      <GlobalStyle />
+      <Editor />
+    </>
+  )
+  
+  render(Main, document.getElementById('app'))
 
 render(Main, document.getElementById('app'))

--- a/src/pages/editor.tsx
+++ b/src/pages/editor.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react'
 import styled from 'styled-components'
+// useState 関数を React から取り出す
+const { useState } = React
 
 const Header = styled.header`
   font-size: 1.5rem;
@@ -44,6 +46,8 @@ const Preview = styled.div`
 `
 // Editor という変数は React.FC という型(Function Componentの略)
 export const Editor: React.FC = () => {
+  // 上に書いたuseStateを使い、以下の１行で状態を管理する処理
+  const [text, setText] = useState<string>('')
   return (
     // 描画されないタグ( <React.Fragment> の略 )
     <>
@@ -51,7 +55,17 @@ export const Editor: React.FC = () => {
         Markdown Editor
       </Header>
       <Wrapper>
-        <TextArea value="テキスト入力エリア" />
+        {/* 以下TextAreaの各属性の状態に関する処理 */}
+        <TextArea
+        // onChangeでテキストの内容が変更された時に実行される関数を渡す、eventという値が引数となる
+          onChange= {(event) => {
+            // event.target.value にテキストの内容が格納される
+            // 50行目のsetTextに引数として渡すことで、状態を更新
+            setText(event.target.value)
+          }}
+          // TextArea の value という属性に50行目のuseStateで管理してる変数textにテキストの内容を渡す
+          value={text}
+          />
         <Preview>プレビューエリア</Preview>
       </Wrapper>
     </>

--- a/src/pages/editor.tsx
+++ b/src/pages/editor.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import styled from 'styled-components'
-// useState 関数を React から取り出す
-const { useState } = React
+import { useStateWithStorage } from '../hooks/user_state_with_storage'
 
 const Header = styled.header`
   font-size: 1.5rem;
@@ -44,10 +43,12 @@ const Preview = styled.div`
   top: 0;
   width: 50vw;
 `
+// localStorage でデータの参照・保存に使うキー名を決める,'ファイルパス:値の名前'
+const StorageKey = 'pages/editor:text'
 // Editor という変数は React.FC という型(Function Componentの略)
 export const Editor: React.FC = () => {
   // 上に書いたuseStateを使い、以下の１行で状態を管理する処理
-  const [text, setText] = useState<string>('')
+  const [text, setText] = useStateWithStorage('',StorageKey)
   return (
     // 描画されないタグ( <React.Fragment> の略 )
     <>
@@ -58,12 +59,8 @@ export const Editor: React.FC = () => {
         {/* 以下TextAreaの各属性の状態に関する処理 */}
         <TextArea
         // onChangeでテキストの内容が変更された時に実行される関数を渡す、eventという値が引数となる
-          onChange= {(event) => {
-            // event.target.value にテキストの内容が格納される
-            // 50行目のsetTextに引数として渡すことで、状態を更新
-            setText(event.target.value)
-          }}
-          // TextArea の value という属性に50行目のuseStateで管理してる変数textにテキストの内容を渡す
+          onChange= {(event) => setText(event.target.value)}
+          // TextArea の value という属性に51行目のuseStateで管理してる変数textにテキストの内容を渡す
           value={text}
           />
         <Preview>プレビューエリア</Preview>

--- a/src/pages/editor.tsx
+++ b/src/pages/editor.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react'
+import styled from 'styled-components'
+
+const Header = styled.header`
+  font-size: 1.5rem;
+  height: 2rem;
+  left: 0;
+  line-height: 2rem;
+  padding: 0.5rem 1rem;
+  position: fixed;
+  right: 0;
+  top: 0;
+`
+
+const Wrapper = styled.div`
+  bottom: 0;
+  left: 0;
+  position: fixed;
+  right: 0;
+  top: 3rem;
+`
+
+const TextArea = styled.textarea`
+  border-right: 1px solid silver;
+  border-top: 1px solid silver;
+  bottom: 0;
+  font-size: 1rem;
+  left: 0;
+  padding: 0.5rem;
+  position: absolute;
+  top: 0;
+  width: 50vw;
+`
+
+const Preview = styled.div`
+  border-top: 1px solid silver;
+  bottom: 0;
+  overflow-y: scroll;
+  padding: 1rem;
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 50vw;
+`
+// Editor という変数は React.FC という型(Function Componentの略)
+export const Editor: React.FC = () => {
+  return (
+    // 描画されないタグ( <React.Fragment> の略 )
+    <>
+      <Header>
+        Markdown Editor
+      </Header>
+      <Wrapper>
+        <TextArea value="テキスト入力エリア" />
+        <Preview>プレビューエリア</Preview>
+      </Wrapper>
+    </>
+  )
+}


### PR DESCRIPTION
- `React.FC`はFunction Componentの略
- `<> </>`の空タグは `<React.Fragment>` の略
    - 無駄な`<div>`タグを描画しない為
- React Hooksを使って`useState`による状態管理 
- ブラウザの機能であるWeb Storage の１つの`localStorage`を使用

## 参照
https://ja.reactjs.org/docs/components-and-props.html#function-and-class-components
https://ja.reactjs.org/docs/fragments.html
https://developer.mozilla.org/ja/docs/Web/API/Web_Storage_API#window.localstorage